### PR TITLE
Use macro `@struct_hash_equal_isequal_isapprox` in `Particle`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+StructEquality = "6ec83bb0-ed9f-11e9-3b4c-2b04cb4e219c"
 
 [compat]
 JSON = "0.21"

--- a/src/mechanics.jl
+++ b/src/mechanics.jl
@@ -39,9 +39,9 @@ function Acceleration(a::Particle)
     end
 end
 
-function acceleration(cell::Cell, particle::Particle, position)
-    neighbors = list_neighbors(cell, particle)
-    return sum(Acceleration(Particle(position)), neighbors)
+function acceleration(cell::Cell, particle::Particle, new_position)
+    neighbors = list_neighbors(cell, particle, new_position)
+    return sum(Acceleration(Particle(new_position, particle.velocity)), neighbors)
 end
 function acceleration(cell::Cell, particle::Particle)
     neighbors = list_neighbors(cell, particle)

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -1,5 +1,6 @@
 using LinearAlgebra: norm
 using StaticArrays: MVector, FieldVector
+using StructEquality: @struct_hash_equal_isequal_isapprox
 
 export Position, Velocity, Acceleration, Particle, Cell
 export distance,
@@ -32,12 +33,9 @@ mutable struct Acceleration <: FieldVector{3,Float64}
     z::Float64
 end
 
-mutable struct Particle
+@struct_hash_equal_isequal_isapprox mutable struct Particle
     position::Position
     velocity::Velocity
-    Particle(position, velocity) = new(position, velocity)
-    Particle(position) = new(position)
-    Particle() = new()  # Incomplete initialization
 end
 
 struct Cell

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -1,0 +1,7 @@
+@testset "Test the `Particle` constructor" begin
+    @test Particle([1, 2, 3], [4, 5, 6]) == Particle([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+    @test Particle([1//1, 2, 9//3], [4, 10//2, 6]) == Particle([1, 2.0, 3], [4.0, 5, 6])
+    @test Particle([1.1, 2.3, 3], [4 / 3, 5, 6]) ==
+        Particle([1.1, 2.3, 3.0], [4//3, 5.0, 6.0])
+    @test_throws MethodError Particle([1, 2, 3])
+end

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -5,3 +5,9 @@
         Particle([1.1, 2.3, 3.0], [4//3, 5.0, 6.0])
     @test_throws MethodError Particle([1, 2, 3])
 end
+
+@testset "Test function `isapprox` on `Particle`s" begin
+    a = Particle([1, 2, 3], [4, 5, 6])
+    b = Particle([1, 2, 3] .+ 1e-10, [4, 5, 6] .- 1e-10)
+    @test isapprox(a, b)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,5 @@ using MolecularDynamics
 using Test
 
 @testset "MolecularDynamics.jl" begin
-    # Write your tests here.
+    include("particles.jl")
 end


### PR DESCRIPTION
Deprecate `Particle` constructors with incomplete arguments