### PR TITLE
Rename type `Position` to `Coordinates`, and Rename `Particle.position` to `Particle.coordinates`

### DIFF
--- a/src/integrators.jl
+++ b/src/integrators.jl
@@ -2,7 +2,7 @@ using ElasticArrays: ElasticMatrix
 using ProgressMeter: @showprogress
 
 export VelocityVerlet, TimeStepTracker
-export take_one_step!, take_n_steps!, velocities, positions
+export take_one_step!, take_n_steps!, extract_velocities, extract_coordinates
 
 abstract type Integrator end
 struct VelocityVerlet <: Integrator end
@@ -45,15 +45,15 @@ function take_n_steps!(tracker::TimeStepTracker, particles, box::Box, n, ::Veloc
     return tracker
 end
 
-function velocities(tracker::TimeStepTracker)
+function extract_velocities(tracker::TimeStepTracker)
     return map(tracker.steps) do particle
         particle.velocity
     end
 end
 
-function positions(tracker::TimeStepTracker)
+function extract_coordinates(tracker::TimeStepTracker)
     return map(tracker.steps) do particle
-        particle.position
+        particle.coordinates
     end
 end
 

--- a/src/integrators.jl
+++ b/src/integrators.jl
@@ -13,17 +13,17 @@ struct TimeStepTracker
 end
 
 function take_one_step!(particles, box::Box, Δt, ::VelocityVerlet)
-    new_positions = map(particles, acceleration(particles, box)) do particle, 𝐚
+    new_coordinates = map(particles, acceleration(particles, box)) do particle, 𝐚
         particle.velocity += 𝐚 * Δt / 2  # 𝐯(t + Δt / 2)
-        new_position = particle.position + particle.velocity * Δt  # 𝐫(t + Δt)
-        new_position = map(Base.Fix2(mod, box.side_length), new_position)  # Move `𝐫` back to `0 - L` range
+        coordinates = particle.coordinates + particle.velocity * Δt  # 𝐫(t + Δt)
+        coordinates = map(Base.Fix2(mod, box.side_length), coordinates)  # Move `𝐫` back to `0 - L` range
     end
-    for (particle, new_position) in zip(particles, new_positions)
-        𝐚 = acceleration(particle, new_position, particles, box)  # 𝐚(t + Δt)
+    for (particle, coordinates) in zip(particles, new_coordinates)
+        𝐚 = acceleration(particle, coordinates, particles, box)  # 𝐚(t + Δt)
         particle.velocity += 𝐚 * Δt / 2  # 𝐯(t + Δt)
     end
-    for (particle, new_position) in zip(particles, new_positions)
-        particle.position = new_position
+    for (particle, coordinates) in zip(particles, new_coordinates)
+        particle.coordinates = coordinates
     end
     return particles
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -3,7 +3,7 @@ using JSON: JSON
 export save, load
 
 function Base.Dict(particle::Particle)
-    return Dict("position" => particle.position, "velocity" => particle.velocity)
+    return Dict("coordinates" => particle.coordinates, "velocity" => particle.velocity)
 end
 
 function Base.print(io::IO, particle::Particle)

--- a/src/mechanics.jl
+++ b/src/mechanics.jl
@@ -39,13 +39,13 @@ function Acceleration(a::Particle)
     end
 end
 
-function acceleration(i::Integer, new_position, particles, box::Box)
+function acceleration(i::Integer, new_coordinates, particles, box::Box)
     neighbors = find_neighbors(i, particles, box)
-    return sum(Acceleration(Particle(new_position, particles[i].velocity)), neighbors)
+    return sum(Acceleration(Particle(new_coordinates, particles[i].velocity)), neighbors)
 end
-function acceleration(particle::Particle, new_position, particles, box::Box)
+function acceleration(particle::Particle, new_coordinates, particles, box::Box)
     neighbors = find_neighbors(particle, particles, box)
-    return sum(Acceleration(Particle(new_position, particle.velocity)), neighbors)
+    return sum(Acceleration(Particle(new_coordinates, particle.velocity)), neighbors)
 end
 function acceleration(i::Integer, particles, box::Box)
     neighbors = find_neighbors(i, particles, box)

--- a/src/mechanics.jl
+++ b/src/mechanics.jl
@@ -8,8 +8,8 @@ function potential_energy(r::Number)
     return 4 * (r⁻¹² - r⁻⁶)
 end
 potential_energy(𝐫ᵢⱼ) = potential_energy(norm(𝐫ᵢⱼ))
-potential_energy(𝐫::Position, 𝐫′::Position) = potential_energy(𝐫 .- 𝐫′)
-potential_energy(a::Particle, b::Particle) = potential_energy(a.position, b.position)
+potential_energy(𝐫::Coordinates, 𝐫′::Coordinates) = potential_energy(𝐫 .- 𝐫′)
+potential_energy(a::Particle, b::Particle) = potential_energy(a.coordinates, b.coordinates)
 function potential_energy(particles::AbstractVector{Particle})
     return sum(eachindex(particles)) do i
         sum(filter(!=(i), eachindex(particles))) do j
@@ -35,7 +35,7 @@ Calculate the acceleration particle `b` induces on particle `a` (direction: from
 """
 function Acceleration(a::Particle)
     return function (b::Particle)
-        return Acceleration(potential_gradient(b.position .- a.position))
+        return Acceleration(potential_gradient(b.coordinates .- a.coordinates))
     end
 end
 

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -8,7 +8,7 @@ export distance,
     boxsize,
     boxvolume,
     number_density,
-    init_positions!,
+    init_coordinates!,
     init_velocities!,
     init!,
     damp!,
@@ -96,7 +96,7 @@ function find_neighbors(a::Particle, new_position, particles, box::Box)
     end
 end
 
-function init_positions!(particles, box::Box)
+function init_coordinates!(particles, box::Box)
     # for particle in particles
     #     particle.coordinates = boxsize(box) .* rand(3)
     # end
@@ -115,7 +115,7 @@ function init_velocities!(particles)
 end
 
 function init!(particles, box::Box)
-    init_positions!(particles, box)
+    init_coordinates!(particles, box)
     init_velocities!(particles)
     return particles
 end

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -2,7 +2,7 @@ using LinearAlgebra: norm
 using StaticArrays: MVector, FieldVector
 using StructEquality: @struct_hash_equal_isequal_isapprox
 
-export Position, Velocity, Acceleration, Particle, CubicBox
+export Coordinates, Velocity, Acceleration, Particle, CubicBox
 export distance,
     find_neighbors,
     boxsize,
@@ -15,7 +15,7 @@ export distance,
     getcoordinates,
     getvelocities
 
-mutable struct Position <: FieldVector{3,Float64}
+mutable struct Coordinates <: FieldVector{3,Float64}
     x::Float64
     y::Float64
     z::Float64
@@ -34,11 +34,11 @@ mutable struct Acceleration <: FieldVector{3,Float64}
 end
 
 @struct_hash_equal_isequal_isapprox mutable struct Particle
-    position::Position
+    coordinates::Coordinates
     velocity::Velocity
 end
-Particle(particle::Particle, velocity) = Particle(particle.position, velocity)
-Particle(position, particle::Particle) = Particle(position, particle.velocity)
+Particle(particle::Particle, velocity) = Particle(particle.coordinates, velocity)
+Particle(coordinates, particle::Particle) = Particle(coordinates, particle.velocity)
 
 abstract type Box end
 struct CubicBox <: Box
@@ -53,13 +53,13 @@ struct CubicBox <: Box
 end
 
 distance(𝐫, 𝐫′) = norm(𝐫 .- 𝐫′)
-distance(a::Particle, b::Particle) = distance(a.position, b.position)
+distance(a::Particle, b::Particle) = distance(a.coordinates, b.coordinates)
 
 function find_nearest_image(b::Particle, box::Box)
     L = box.side_length
-    𝐫 = map(Base.Fix2(mod, L), b.position)
+    𝐫 = map(Base.Fix2(mod, L), b.coordinates)
     return function (a::Particle)
-        Δ𝐫 = 𝐫 - a.position
+        Δ𝐫 = 𝐫 - a.coordinates
         𝐫′ = map(𝐫, Δ𝐫) do rᵢ, Δrᵢ
             if Δrᵢ > L / 2
                 rᵢ - L
@@ -98,10 +98,10 @@ end
 
 function init_positions!(particles, box::Box)
     # for particle in particles
-    #     particle.position = boxsize(box) .* rand(3)
+    #     particle.coordinates = boxsize(box) .* rand(3)
     # end
     for (particle, r) in zip(particles, vec(collect(Iterators.product(1:10, 1:10, 1:10))))
-        particle.position = collect(r) * 1.1
+        particle.coordinates = collect(r) * 1.1
     end
     @assert unique(particles) == particles
     return particles
@@ -133,7 +133,7 @@ boxvolume(box::CubicBox) = reduce(*, boxsize(box))
 number_density(particles, box::CubicBox) = length(particles) / boxvolume(box)
 
 function Base.in(particle::Particle, box::CubicBox)
-    return all(particle.position) do x
+    return all(particle.coordinates) do x
         0 <= x <= box.side_length
     end
 end

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -84,15 +84,17 @@ function find_neighbors(a::Particle, particles, box::Box)
         find_nearest_image(b, box)(a)
     end
 end
-function find_neighbors(i::Integer, new_position, particles, box::Box)
+function find_neighbors(i::Integer, new_coordinates, particles, box::Box)
     return map(filter(!=(i), eachindex(particles))) do j
-        find_nearest_image(particles[j], box)(Particle(new_position, particles[i].velocity))
+        find_nearest_image(particles[j], box)(
+            Particle(new_coordinates, particles[i].velocity)
+        )
     end
 end
-function find_neighbors(a::Particle, new_position, particles, box::Box)
+function find_neighbors(a::Particle, new_coordinates, particles, box::Box)
     @assert a in particles
     return map(filter(!=(a), particles)) do b
-        find_nearest_image(b, box)(Particle(new_position, a.velocity))
+        find_nearest_image(b, box)(Particle(new_coordinates, a.velocity))
     end
 end
 
@@ -139,20 +141,20 @@ function Base.in(particle::Particle, box::CubicBox)
 end
 
 function getcoordinates(particles)
-    positions = map(particles) do particle
-        particle.position
+    allcoordinates = map(particles) do particle
+        particle.coordinates
     end
     return function (; x=true, y=true, z=true)
         results = ntuple(_ -> Float64[], 3)
-        map(positions) do position
+        map(allcoordinates) do coordinates
             if x
-                push!(results[1], position.x)
+                push!(results[1], coordinates.x)
             end
             if y
-                push!(results[2], position.y)
+                push!(results[2], coordinates.y)
             end
             if z
-                push!(results[3], position.z)
+                push!(results[3], coordinates.z)
             end
         end
         return results

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -24,7 +24,7 @@ end
         @test particle ∉ neighbors
         @test length(neighbors) == length(particles) - 1
         @test all(neighbors) do neighbor
-            𝐫 = neighbor.position .- particle.position
+            𝐫 = neighbor.coordinates .- particle.coordinates
             all(0 <= abs(rᵢ) <= Lᵢ for (rᵢ, Lᵢ) in zip(𝐫, boxsize(box)))
         end
     end


### PR DESCRIPTION
Since `Position` - `Position` is not a `Position`, but `Coordinates` - `Coordinates` is still a `Coordinates`